### PR TITLE
SDWAN-290 | fix core in quicly during connection interruption 

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -257,9 +257,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 #define SET_ALARM(t)                                                                                                               \
     do {                                                                                                                           \
         int64_t _t = (t);                                                                                                          \
-        if (is_after_send) {                                                                                                       \
-            assert(now < _t);                                                                                                      \
-        } else if (_t < now) {                                                                                                     \
+        if (_t < now) {                                                                                                            \
             _t = now;                                                                                                              \
         }                                                                                                                          \
         r->alarm_at = _t;                                                                                                          \


### PR DESCRIPTION
removing the assert in `SET_ALARM` macro.
there seems to be some incorrect decision of asserting when the `alarm start point + duration > now` 
logically this is something which shouldn't occur, however:
 in [this case](https://github.com/twingate/quicly/blob/d74200136a94f761f62fa2fbc181f287fc8cc120/include/quicly/loss.h#L317) `alarm_duration` is a heuristic value which is calculated with a variance (see [rtt→variance](https://github.com/twingate/quicly/blob/d74200136a94f761f62fa2fbc181f287fc8cc120/include/quicly/loss.h#L244)).

with this heuristic duration last_retransmittable_sent_at + alarm_duration can easily go into a future time (pass the now which we assert on).