### PR TITLE
SDWAN-290 | fix core in quicly during connection interruption

### DIFF
--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -265,9 +265,9 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
     do {                                                                                                                           \
         int64_t _t = (t);                                                                                                          \
         if (is_after_send) {                                                                                                       \
-            if(now < _t) {                                                                                                         \
-                _t = now;                                                                                                          \
-            }                                                                                                                      \ 
+            /*mask this assert, but don't modify the logic                                                                         \
+            n case is_after_send is true don't update _t                                                                           \
+              assert(now < _t);*/                                                                                                  \
         } else if (_t < now) {                                                                                                     \
             _t = now;                                                                                                              \
         }                                                                                                                          \

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -264,7 +264,11 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 #define SET_ALARM(t)                                                                                                               \
     do {                                                                                                                           \
         int64_t _t = (t);                                                                                                          \
-        if (_t < now) {                                                                                                            \
+        if (is_after_send) {                                                                                                       \
+            if(now < _t) {                                                                                                         \
+                _t = now;                                                                                                          \
+            }                                                                                                                      \ 
+        } else if (_t < now) {                                                                                                     \
             _t = now;                                                                                                              \
         }                                                                                                                          \
         r->alarm_at = _t;                                                                                                          \

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -264,9 +264,7 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
 #define SET_ALARM(t)                                                                                                               \
     do {                                                                                                                           \
         int64_t _t = (t);                                                                                                          \
-        if (is_after_send) {                                                                                                       \
-            assert(now < _t);                                                                                                      \
-        } else if (_t < now) {                                                                                                     \
+        if (_t < now) {                                                                                                            \
             _t = now;                                                                                                              \
         }                                                                                                                          \
         r->alarm_at = _t;                                                                                                          \

--- a/include/quicly/loss.h
+++ b/include/quicly/loss.h
@@ -266,8 +266,9 @@ inline void quicly_loss_update_alarm(quicly_loss_t *r, int64_t now, int64_t last
         int64_t _t = (t);                                                                                                          \
         if (is_after_send) {                                                                                                       \
             /*mask this assert, but don't modify the logic                                                                         \
-            n case is_after_send is true don't update _t                                                                           \
-              assert(now < _t);*/                                                                                                  \
+            in case is_after_send is true update _t to be in the future                                                            \
+            assert(now < _t);*/                                                                                                    \
+            _t = (now < _t) ? _t : now + 1;                                                                                        \
         } else if (_t < now) {                                                                                                     \
             _t = now;                                                                                                              \
         }                                                                                                                          \


### PR DESCRIPTION
create this branch out of `upstream-2022-12-29` instead of `master`

removing the assert in SET_ALARM macro.
there seems to be some incorrect decision of asserting when the alarm start point + duration > now
logically this is something which shouldn't occur, however:
in [this case](https://github.com/twingate/quicly/blob/d74200136a94f761f62fa2fbc181f287fc8cc120/include/quicly/loss.h#L317) alarm_duration is a heuristic value which is calculated with a variance (see [rtt→variance](https://github.com/twingate/quicly/blob/d74200136a94f761f62fa2fbc181f287fc8cc120/include/quicly/loss.h#L244)).

with this heuristic duration last_retransmittable_sent_at + alarm_duration can easily go into a future time (pass the now which we assert on).